### PR TITLE
Implement Application::copyToClipboard for iOS

### DIFF
--- a/docs/docs/reference/foundation/application.md
+++ b/docs/docs/reference/foundation/application.md
@@ -74,6 +74,10 @@ namespace bdn {
 
 	Opens the given URL in a suitable external application. Web URLs will be opened in the system's standard web browser. Application-specific URLs will open in the respective application.
 
+* **virtual void copyToClipboard(const String &str)**
+
+	Copies the given string to the clipboard.
+
 ## Resources
 
 * **virtual String uriToBundledFileUri(const String &uri)**

--- a/examples/BodenDemo/src/BodenDemo.cpp
+++ b/examples/BodenDemo/src/BodenDemo.cpp
@@ -8,6 +8,7 @@
 #include "FontPage.h"
 #include "ImagesPage.h"
 #include "ListViewPage.h"
+#include "MiscPage.h"
 #include "PropertiesPage.h"
 #include "StyledTextPage.h"
 #include "TimersPage.h"
@@ -23,7 +24,7 @@ using namespace bdn;
 class PagesDataSource : public ListViewDataSource
 {
   public:
-    std::array<std::pair<String, std::function<std::shared_ptr<View>()>>, 10> pages = {
+    std::array<std::pair<String, std::function<std::shared_ptr<View>()>>, 11> pages = {
         std::make_pair("UI Demo", [=]() { return std::make_shared<UIDemoPage>(needsInit, _window); }),
         std::make_pair("Timer demo", [=]() { return std::make_shared<TimersPage>(needsInit); }),
         std::make_pair("WebView demo", [=]() { return std::make_shared<WebViewPage>(needsInit); }),
@@ -34,6 +35,7 @@ class PagesDataSource : public ListViewDataSource
         std::make_pair("Fonts", [=]() { return std::make_shared<FontPage>(needsInit); }),
         std::make_pair("Styled Text", [=]() { return std::make_shared<StyledTextPage>(needsInit); }),
         std::make_pair("Focus", [=]() { return std::make_shared<FocusPage>(needsInit); }),
+        std::make_pair("Misc", [=]() { return std::make_shared<MiscPage>(needsInit); }),
     };
 
   public:

--- a/examples/BodenDemo/src/MiscPage.cpp
+++ b/examples/BodenDemo/src/MiscPage.cpp
@@ -1,0 +1,21 @@
+#include <bdn/Application.h>
+#include <bdn/Json.h>
+#include <bdn/ui/Button.h>
+#include <bdn/ui/ContainerView.h>
+#include <bdn/ui/yoga/FlexStylesheet.h>
+
+#include "MiscPage.h"
+#include <bdn/log.h>
+
+namespace bdn
+{
+    void MiscPage::init()
+    {
+        stylesheet = FlexJsonStringify({"flexGrow" : 1.0});
+
+        auto buttonCopy = std::make_shared<Button>();
+        buttonCopy->label = "Hello clipboard!";
+        buttonCopy->onClick() += [](auto) { App()->copyToClipboard("Hello clipboard!"); };
+        addChildView(makeRow("Clipboard", buttonCopy, 0.));
+    }
+}

--- a/examples/BodenDemo/src/MiscPage.h
+++ b/examples/BodenDemo/src/MiscPage.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Page.h"
+
+namespace bdn
+{
+    class MiscPage : public ui::CoreLess<ContainerView>
+    {
+      public:
+        using CoreLess<ContainerView>::CoreLess;
+        void init() override;
+    };
+}

--- a/framework/foundation/include/bdn/Application.h
+++ b/framework/foundation/include/bdn/Application.h
@@ -53,6 +53,7 @@ namespace bdn
       public:
         virtual void openURL(const String &url) = 0;
         virtual String uriToBundledFileUri(const String &uri) { return uri; }
+        virtual void copyToClipboard(const String &str) = 0;
 
       protected:
         virtual void platformSpecificInit() {}

--- a/framework/foundation/include/bdn/GenericApplication.h
+++ b/framework/foundation/include/bdn/GenericApplication.h
@@ -70,6 +70,8 @@ namespace bdn
 
         void openURL(const String &url) override {}
 
+        void copyToClipboard(const String &str) override {}
+
       protected:
         virtual bool shouldExit() const
         {

--- a/framework/ui/platforms/android/include/bdn/android/UIApplication.h
+++ b/framework/ui/platforms/android/include/bdn/android/UIApplication.h
@@ -23,6 +23,7 @@ namespace bdn::ui::android
         void initiateExitIfPossible(int exitCode) override;
         void openURL(const String &url) override;
         String uriToBundledFileUri(const String &uri) override;
+        void copyToClipboard(const String &str) override;
 
       protected:
         void disposeMainDispatcher() override;

--- a/framework/ui/platforms/android/include/bdn/android/wrapper/NativeRootActivity.h
+++ b/framework/ui/platforms/android/include/bdn/android/wrapper/NativeRootActivity.h
@@ -16,6 +16,9 @@ namespace bdn::android::wrapper
         constexpr static const JTObject<kNativeRootActivityClassName>::StaticMethod<String(String)>
             getResourceURIFromURI{"getResourceURIFromURI"};
 
+        constexpr static const JTObject<kNativeRootActivityClassName>::StaticMethod<void(String)> copyToClipboard{
+            "copyToClipboard"};
+
         // JavaMethod<void(java::wrapper::CharSequence)> setTitle{this, "setTitle"};
         // JavaMethod<void(bool)> enableBackButton{this, "enableBackButton"};
     };

--- a/framework/ui/platforms/android/java/io/boden/android/NativeRootActivity.java
+++ b/framework/ui/platforms/android/java/io/boden/android/NativeRootActivity.java
@@ -3,6 +3,7 @@ package io.boden.android;
 import io.boden.android.NativeInit;
 import io.boden.android.NativeRootView;
 
+import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
@@ -290,6 +291,12 @@ public class NativeRootActivity extends AppCompatActivity
         }
 
         return uri;
+    }
+
+    public static final void copyToClipboard(String str)
+    {
+        ClipboardManager clipboard = (ClipboardManager)getRootActivity().getSystemService(Context.CLIPBOARD_SERVICE);
+        clipboard.setText(str);
     }
 
     @Override

--- a/framework/ui/platforms/android/src/UIApplication.cpp
+++ b/framework/ui/platforms/android/src/UIApplication.cpp
@@ -75,6 +75,11 @@ namespace bdn::ui::android
     {
         return bdn::android::wrapper::NativeRootActivity::getResourceURIFromURI(uri);
     }
+
+    void UIApplication::copyToClipboard(const String &str)
+    {
+        return bdn::android::wrapper::NativeRootActivity::copyToClipboard(str);
+    }
 }
 
 extern "C" JNIEXPORT void JNICALL Java_io_boden_android_NativeInit_nativeDestroy(JNIEnv *env, jclass cls,

--- a/framework/ui/platforms/ios/include/bdn/ios/UIApplication.hh
+++ b/framework/ui/platforms/ios/include/bdn/ios/UIApplication.hh
@@ -22,6 +22,8 @@ namespace bdn::ui::ios
 
         String uriToBundledFileUri(const String &uri) override;
 
+        void copyToClipboard(const String &str) override;
+
       public:
         bool _applicationWillFinishLaunching(NSDictionary *launchOptions);
         bool _applicationDidFinishLaunching(NSDictionary *launchOptions);

--- a/framework/ui/platforms/ios/src/UIApplication.mm
+++ b/framework/ui/platforms/ios/src/UIApplication.mm
@@ -150,6 +150,12 @@ namespace bdn::ui::ios
         return "file:///" + result;
     }
 
+    void UIApplication::copyToClipboard(const String &str)
+    {
+        UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
+        pasteboard.string = [NSString stringWithUTF8String:str.c_str()];
+    }
+
     bool UIApplication::_applicationWillFinishLaunching(NSDictionary *launchOptions)
     {
         bdn::platformEntryWrapper(

--- a/framework/ui/platforms/mac/include/bdn/mac/UIApplication.hh
+++ b/framework/ui/platforms/mac/include/bdn/mac/UIApplication.hh
@@ -19,6 +19,7 @@ namespace bdn::ui::mac
         void disposeMainDispatcher() override;
         void openURL(const String &url) override;
         String uriToBundledFileUri(const String &uri) override;
+        void copyToClipboard(const String &str) override;
 
       public:
         void _applicationWillFinishLaunching(NSNotification *notification);

--- a/framework/ui/platforms/mac/src/UIApplication.mm
+++ b/framework/ui/platforms/mac/src/UIApplication.mm
@@ -137,6 +137,13 @@ namespace bdn::ui::mac
         return "file:///" + result;
     }
 
+    void UIApplication::copyToClipboard(const String &str)
+    {
+        NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+        [pasteboard declareTypes:[NSArray arrayWithObjects:NSPasteboardTypeString, nil] owner:nil];
+        [pasteboard setString:[NSString stringWithUTF8String:str.c_str()] forType:NSPasteboardTypeString];
+    }
+
     void UIApplication::_applicationWillFinishLaunching(NSNotification *notification)
     {
         bdn::platformEntryWrapper(


### PR DESCRIPTION
Usage:

```
App()->copyToClipboard("Hello clipboard");
```

Currently I do not have enough disk space to test on an emulator on Android unfortunately. I will try to make space and implement it for Android and OSX too. I'll sign the CLA in a separate PR once that's applicable.