### PR TITLE
Replace \ with \\ to fix invalid escape sequence in CMakeLists.txt

### DIFF
--- a/bauer/templatecreator.py
+++ b/bauer/templatecreator.py
@@ -48,7 +48,7 @@ class TemplateCreator:
         vars = {
             'project_name' : args.project_name,
             'project_folder' : project_folder,
-            'boden_relative_path' : boden_relative_path
+            'boden_relative_path' : boden_relative_path.replace('\\', '\\\\')
         }
 
         self.logger.info("Creating project in %s", project_folder)


### PR DESCRIPTION
This will change:

```
add_subdirectory(..\Tools\boden boden)
```

to:

```
add_subdirectory(..\\Tools\\boden boden)
```

in path/to/project/CMakeLists.txt.